### PR TITLE
Improvements to installation for CI services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+shellcheck-latest/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-shellcheck-latest/

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "shellcheck": "shellcheck-latest/shellcheck"
   },
   "scripts": {
-    "test": "shellcheck ./postinstall.sh",
-    "preinstall": "./postinstall.sh"
+    "test": "shellcheck *.sh",
+    "preinstall": "./preinstall.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "shellcheck *.sh",
-    "preinstall": "./preinstall.sh"
+    "preinstall": "./preinstall.sh",
+    "version": "rm -rf shellcheck-latest && mkdir shellcheck-latest && touch shellcheck-latest/shellcheck"
   },
   "repository": {
     "type": "git",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -e
-
-# Download
-wget https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz
-tar xf shellcheck-latest.linux.x86_64.tar.xz
-
-# Clean up
-rm shellcheck-latest.linux.x86_64.tar.xz

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+# Download
+File=shellcheck-latest.linux.x86_64.tar.xz
+curl -o $File https://storage.googleapis.com/shellcheck/$File
+tar xf $File
+
+# Clean up
+rm -f $File


### PR DESCRIPTION
### Changes

- Switches downloads from `wget` to `curl`, which is preinstalled on more systems
- Renames `postinstall.sh` to `preinstall.sh`, not necessary but make sense in the context of npm's workflow
  - Also adds shell variable, again, not necessary but an improvement
- Reintroduces (blank) placeholder file `shellcheck-latest/shellcheck`, which fixes installation to `node_modules/.bin` for `yarn`
  - Adds `npm run version` script, which ensures that above placeholder folder and file are empty when running `npm version`.

Closes #1 