### PR TITLE
Maintain shellcheck symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/package-lock.json
+/yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /package-lock.json
 /yarn.lock
+
+/shellcheck-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /package-lock.json
 /yarn.lock
+/shellcheck-*.tgz
 
 /shellcheck-latest

--- a/install.sh
+++ b/install.sh
@@ -12,18 +12,14 @@ http_client() {
 }
 
 curl_get() {
-  curl --disable --silent --show-error --fail --location --remote-name "$1"
+  curl --disable --silent --show-error --fail --location "$1"
 }
 
 wget_get() {
-  wget -q "$1"
+  wget -q -O - "$1"
 }
 
-# Download
-"$(http_client)_get" https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz
+tarball_url=https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz
 
-# Extract
-tar xf shellcheck-latest.linux.x86_64.tar.xz
-
-# Clean up
-rm shellcheck-latest.linux.x86_64.tar.xz
+# Download & Extract
+"$(http_client)_get" "$tarball_url" | tar -x -f -

--- a/install.sh
+++ b/install.sh
@@ -22,4 +22,4 @@ wget_get() {
 tarball_url=https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz
 
 # Download & Extract
-"$(http_client)_get" "$tarball_url" | tar -x -f -
+"$(http_client)_get" "$tarball_url" | tar -qx -f - --include '*/shellcheck'

--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "name": "shellcheck",
   "version": "0.2.2",
   "description": "Wrapper to download shellcheck",
-  "bin": "./run.sh",
+  "directories": {
+    "bin": "./shellcheck-latest"
+  },
+  "files": [
+    "install.sh",
+    "shellcheck-latest"
+  ],
   "scripts": {
     "test": "shellcheck *.sh",
-    "preinstall": "./install.sh"
+    "prepare": "./install.sh"
   },
   "repository": {
     "type": "git",

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec shellcheck-latest/shellcheck "$@"


### PR DESCRIPTION
Run the install (fetch) script at both installation and pre-publishing.

Running it at publish time ensures there is at least a fallback binary to include in the npm tarball. This guarantees that npm will create the bin symlink. Also, it provides a fallback binary in case the fetch/untar fails. When the install runs on the client, it will overwrite the bundled bin so that the user will still have the latest version.

This PR also speeds up the fetching process:
- doesn't write the tarball to disk (only to remove it immediately); instead pipes directly to tar
- does a fast untar by exiting as soon as it finds the first file matching the pattern.

fixes #11 

tested by local npm-link, by installing with relative file path, and also by installing directly from git using this branch. (all using npm 6.5.0)

bin symlink created successfully in all three cases.