### PR TITLE
Handle both BSD and GNU tar

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,4 +22,4 @@ wget_get() {
 tarball_url=https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz
 
 # Download & Extract
-"$(http_client)_get" "$tarball_url" | tar -qx -f - --include '*/shellcheck'
+"$(http_client)_get" "$tarball_url" | tar -xz


### PR DESCRIPTION
GNU tar doesn't have -q or --include.
BSD tar doesn't have --occurrence

So we skip the "fast extract" optimization and just extract the whole
archive :(