### PR TITLE
Gcg/tar gtar

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -e
 
 http_client() {
   for client in curl wget; do

--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,15 @@ wget_get() {
   wget -q -O - "$1"
 }
 
+tar_options() {
+  if [[ "$(tar --version)" = bsdtar* ]]; then
+    echo -xz
+  else
+    echo -xJ
+  fi
+}
+
 tarball_url=https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz
 
 # Download & Extract
-tar_options=$([[ "$(tar --version)" = bsdtar* ]] && echo -xz || echo -xJ)
-"$(http_client)_get" "$tarball_url" | tar $tar_options
+"$(http_client)_get" "$tarball_url" | tar "$(tar_options)"


### PR DESCRIPTION
That worked for me!

However, the use of `[[` means the shell must be `bash`, not `sh`. And while changing the shebang, I took the opportunity to respect the user's version of bash via the /usr/bin/env idiom.

Also moved the options into a function (and quoted for shellcheck happiness).

tweaks to #14 