### PR TITLE
Support macOS/Darwin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,14 @@ tar_options() {
   fi
 }
 
-tarball_url=https://storage.googleapis.com/shellcheck/shellcheck-latest.linux.x86_64.tar.xz
+platform_filename() {
+  case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+  darwin) echo "darwin" ;;
+  *) echo "linux" ;;
+  esac
+}
+
+tarball_url=https://storage.googleapis.com/shellcheck/shellcheck-latest.$(platform_filename).x86_64.tar.xz
 
 # Download & Extract
 "$(http_client)_get" "$tarball_url" | tar "$(tar_options)"

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+[ -z "$DEBUG" ] || { export PS4='+ [shellcheck/${BASH_SOURCE##*/}:${LINENO}] '; set -x; }
+
 http_client() {
   for client in curl wget; do
     if type "$client" >/dev/null 2>/dev/null; then

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "test": "shellcheck *.sh",
-    "prepare": "./install.sh"
+    "preinstall": "./install.sh"
   },
   "repository": {
     "type": "git",

--- a/shellcheck-latest/shellcheck
+++ b/shellcheck-latest/shellcheck
@@ -1,0 +1,6 @@
+#! /usr/bin/env sh
+
+echo "This is a placeholder and should be overwritten during package install."
+echo "If this file exists after installation, the install.sh script was not successful."
+
+exit 1


### PR DESCRIPTION
Adds support for macOS by switching with binary is fetched after
checking the current platform.

This also rolls back the change which bundled a shellcheck binary during
packing (as that binary will rarely be the same as the one needed by the
user's platform).

In order to maintain the binary symlink, a placeholder script is put in
place where the shellcheck binary _will_ be installed. This placeholder
also functions as a helpful warning if the install script fails. (The
placeholder script emits an error message indicating such.)

Lastly, this adds tracing mode to the install script such that `DEBUG=1`
will enable -x shell tracing. ie `DEBUG=1 npm install shellcheck` will
add tracing output.

partial implementation for #8 