### PR TITLE
Download from GitHub

### DIFF
--- a/download.js
+++ b/download.js
@@ -1,11 +1,24 @@
 const https = require('https');
 const fs = require('fs');
 
-const url = `https://storage.googleapis.com/shellcheck/shellcheck-latest.${process.platform}.x86_64.tar.xz`;
-https
-  .get(url, res => {
-    res.pipe(process.stdout);
-  })
-  .on('error', err => {
-    console.log('Error: ' + err.message);
-  });
+const url = `https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.${process.platform}.x86_64.tar.xz`;
+
+const isRedirect = (statusCode) => {
+  return statusCode >= 300 && statusCode < 400;
+};
+
+const download = (url) => {
+  https
+    .get(url, res => {
+      if (isRedirect(res.statusCode)) {
+        download(res.headers.location);
+      } else {
+        res.pipe(process.stdout);
+      }
+    })
+    .on('error', err => {
+      console.log('Error: ' + err.message);
+    });
+};
+
+download(url);


### PR DESCRIPTION
Fixes #19 

Unlike the previous download location, GitHub returns a redirect, which Node doesn't handle natively. Hence you see code there to deal with the redirect and recursively start a download on the next URL.

@gunar This fixes a fatal issue that this repo currently has. See #19 