### PR TITLE
Refactor install script to POSIX shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,14 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 
 [ -z "$DEBUG" ] || { export PS4='+ [shellcheck/${BASH_SOURCE##*/}:${LINENO}] '; set -x; }
 
 tar_options() {
-  if [[ "$(tar --version)" = bsdtar* ]]; then
-    echo -xz
-  else
-    echo -xJ
-  fi
+  case "$(tar --version)" in
+    bsdtar*) echo -xz;;
+    *) echo -xJ;;
+  esac
 }
 
 # Download & Extract


### PR DESCRIPTION
Currently this package cannot be installed without an error on alpine because `bash` does not exist by default. The fix for this is to refactor the `install.sh` script to be POSIX shell.