### PR TITLE
docs: update npm install command to reflect new flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ And makes the binary available at `node_modules/.bin/shellcheck`.
 
 ## Installation
 ```sh
-npm install --dev shellcheck
+npm install shellcheck --save-dev
 ```
 
 ## Usage


### PR DESCRIPTION
--dev is a deprecated command, --save-dev is the current standard